### PR TITLE
feat: far future expire for local cache

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -11,6 +11,8 @@ pypi.storage = file
 storage.dir = /var/lib/pypicloud/packages
 pypi.auth = sql
 
+pypi.package_max_age = 31536000
+
 db.url = sqlite:////var/lib/pypicloud/db.sqlite
 auth.db.url = sqlite:////var/lib/pypicloud/db.sqlite
 


### PR DESCRIPTION
Slack thread: https://zapier.slack.com/archives/C7GDY3SL9/p1585753823094400

Enables `pip` local cache and avoid re-downloading already installed packages from our registry.

Some timings:

* A fresh install takes ~720s.
* A cached install takes ~90s.